### PR TITLE
feat: Changes migrations to array to catch duplicate keys.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,9 +56,9 @@
       }
     },
     "@js-migrations/core": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@js-migrations/core/-/core-3.0.0.tgz",
-      "integrity": "sha512-6Hj4wAkRaNU+HbyLJQuCp34GPGU7PrIaqfnsvkFUXggDic+lpxB+7E83icpWw12eLsqbs/GwsBNSC+hr8vzT/w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@js-migrations/core/-/core-4.0.0.tgz",
+      "integrity": "sha512-oeJwbVsJdJ2i0gZpuP1FwWiji3VFapZSenhKMgIhpBUEGC3qdra9JG180AWpng/yEm0ZnTyi9R4A9H3sxiwiEQ==",
       "requires": {
         "bluebird": "3.5.1",
         "lodash": "4.17.5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "check-coverage": true
   },
   "dependencies": {
-    "@js-migrations/core": "^3.0.0",
+    "@js-migrations/core": "^4.0.0",
     "knex": "^0.14.4",
     "lodash": "^4.17.5",
     "make-error": "^1.3.2"

--- a/readme.md
+++ b/readme.md
@@ -24,12 +24,11 @@ const migrationsRepoFacade = knexMigrationsRepoFactory({
   // Optional property.
   lockTableName: 'migrationsLock',
   // Optional property.
-  migrations: {
-    'your_migration_name': {
-      down: async () => {},
-      up: async () => {}
-    }
-  },
+  migrations: [{
+    down: async () => {},
+    key: 'your_migration_name',
+    up: async () => {},
+  }],
   // Optional property.
   tableName: 'migrations',
 });

--- a/src/FacadeConfig.ts
+++ b/src/FacadeConfig.ts
@@ -1,9 +1,9 @@
-import MigrationDictionary from '@js-migrations/core/dist/utils/types/MigrationDictionary';
+import Migration from '@js-migrations/core/dist/utils/types/Migration';
 import * as knex from 'knex';
 
 export default interface FacadeConfig {
   readonly db: () => Promise<knex>;
   readonly lockTableName: string;
-  readonly migrations: MigrationDictionary;
+  readonly migrations: Migration[];
   readonly tableName: string;
 }

--- a/src/FactoryConfig.ts
+++ b/src/FactoryConfig.ts
@@ -1,9 +1,9 @@
-import MigrationDictionary from '@js-migrations/core/dist/utils/types/MigrationDictionary';
+import Migration from '@js-migrations/core/dist/utils/types/Migration';
 import * as knex from 'knex';
 
 export default interface FactoryConfig {
   readonly db: () => Promise<knex>;
   readonly lockTableName?: string;
-  readonly migrations?: MigrationDictionary;
+  readonly migrations?: Migration[];
   readonly tableName?: string;
 }

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -12,7 +12,7 @@ import updateProcessedMigrations from './functions/updateProcessedMigrations';
 export default (factoryConfig: FactoryConfig): RepoFacade => {
   const facadeConfig: FacadeConfig = {
     lockTableName: 'migrationsLock',
-    migrations: {},
+    migrations: [],
     tableName: 'migrations',
     ...factoryConfig,
   };

--- a/src/functions/getMigrations.ts
+++ b/src/functions/getMigrations.ts
@@ -1,8 +1,8 @@
-import MigrationDictionary from '@js-migrations/core/dist/utils/types/MigrationDictionary';
+import Migration from '@js-migrations/core/dist/utils/types/Migration';
 import FacadeConfig from '../FacadeConfig';
 
 export default (config: FacadeConfig) => {
-  return async (): Promise<MigrationDictionary> => {
+  return async (): Promise<Migration[]> => {
     return config.migrations;
   };
 };


### PR DESCRIPTION
BREAKING CHANGE: Changes migrations to `Migration[]` instead of `MigrationDictionary`.